### PR TITLE
Update Hadoop version and Python requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ language: python
 services:
   - docker
 
-install:
-  - pip install --upgrade pip
-  - pip install ansible==2.3.1
-  - pip install docker
-  - pip install molecule
-
 script:
   - ansible-lint --version
   - cd crs4.hadoop && molecule test

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,16 @@ COPY crs4.hadoop /build/crs4.hadoop/
 COPY playbook.yml requirements.yml /build/
 COPY entrypoint.sh /
 
-RUN echo "assumeyes=1" >> /etc/yum.conf
-RUN yum install epel-release && yum update && \
+RUN echo "assumeyes=1" >> /etc/yum.conf && \
+    yum install epel-release && \
+    yum update && \
     export ANSIBLE_VERSION=$(yum --showduplicates list ansible | grep ^ansible | awk '{print $2}' | grep '2\.3' | tail -n 1) && \
-    yum install "ansible-${ANSIBLE_VERSION}"
-RUN ansible-galaxy install -r /build/requirements.yml && \
-    ansible-playbook /build/playbook.yml
-
-# disable IPv6
-RUN echo "net.ipv6.conf.all.disable_ipv6 = 1" >>/etc/sysctl.conf && \
-    echo "net.ipv6.conf.default.disable_ipv6 = 1" >>/etc/sysctl.conf
-
-RUN yum clean all; rm -rf /build
+    yum install "ansible-${ANSIBLE_VERSION}" && \
+    ansible-galaxy install -r /build/requirements.yml && \
+    ansible-playbook /build/playbook.yml && \
+    echo "net.ipv6.conf.all.disable_ipv6 = 1" >>/etc/sysctl.conf && \
+    echo "net.ipv6.conf.default.disable_ipv6 = 1" >>/etc/sysctl.conf && \
+    yum clean all && rm -rf /build && rm -rf /var/cache/yum
 
 EXPOSE 8020 8042 8088 9000 10020 19888 50010 50020 50070 50075 50090
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Install and configure Hadoop
 
 ```
 $ docker build -t crs4/hadoop .
-$ docker run --name hadoop -p 8020:8020 -p 8042:8042 -p 8088:8088 -p 9000:9000 -p 10020:10020 -p 19888:19888 -p 50010:50010 -p 50020:50020 -p 50070:50070 -p 50075:50075 -p 50090:50090 -v /hadoop:/hadoop crs4/hadoop
+$ docker run --name hadoop -p 8020:8020 -p 8042:8042 -p 8088:8088 -p 9000:9000 -p 10020:10020 -p 19888:19888 -p 50010:50010 -p 50020:50020 -p 50070:50070 -p 50075:50075 -p 50090:50090 -d crs4/hadoop
 $ docker exec -it hadoop bash -l
 
 $ jps
@@ -21,3 +21,14 @@ $ hadoop jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-${V}.j
 $ hdfs dfs -get wc_out
 $ grep hadoop wc_out/part*
 ```
+
+## Overriding the Configuration
+
+```
+$ docker run --rm -it --entrypoint /bin/bash -v /tmp:/tmp crs4/hadoop -c "cp -a /opt/hadoop/etc/hadoop /tmp/hadoop_conf_dir"
+$ sed -i 's|^JAVA_HEAP_MAX=.*$|JAVA_HEAP_MAX=-Xmx2000m|g' /tmp/hadoop_conf_dir/yarn-env.sh
+$ docker run --name hadoop -p 8020:8020 -p 8042:8042 -p 8088:8088 -p 9000:9000 -p 10020:10020 -p 19888:19888 -p 50010:50010 -p 50020:50020 -p 50070:50070 -p 50075:50075 -p 50090:50090 -v /tmp/hadoop_conf_dir:/opt/hadoop/etc/hadoop -d crs4/hadoop
+```
+
+Note that, in `core-site.xml`, `entrypoint.sh` replaces `localhost`
+with the container's hostname.

--- a/crs4.hadoop/defaults/main.yml
+++ b/crs4.hadoop/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-hadoop_version: "2.7.4"
+hadoop_version: "2.8.3"
 hadoop_parent: "/opt"
 hadoop_data_dir: "/hadoop"
 hadoop_log_dir: "/hadoop/logs"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ansible==2.3.3
+docker<3.0.0  # work around https://github.com/ansible/ansible/issues/35612
+molecule


### PR DESCRIPTION
* Updates Hadoop to 2.8.3
* Adds `requirements.txt` so we can fall back to the default Travis `install`
* Temporarily pins the Python Docker version to work around ansible/ansible#35612 (looks like the fix is not included in any stable Ansible release yet)

I have also added a configuration override example to the README.